### PR TITLE
remove session_id as key prop for reports

### DIFF
--- a/tap_logmeinrescue/streams/session_report.py
+++ b/tap_logmeinrescue/streams/session_report.py
@@ -3,7 +3,7 @@ from tap_logmeinrescue.streams.base import BaseLogMeInRescueReportStream
 
 class SessionReportStream(BaseLogMeInRescueReportStream):
     TABLE = 'session_report'
-    KEY_PROPERTIES = ['session_id']
+    KEY_PROPERTIES = []
     API_METHOD = 'GET'
     REPORT_AREA = 0
     REQUIRES = ['technicians']

--- a/tap_logmeinrescue/streams/technician_survey_report.py
+++ b/tap_logmeinrescue/streams/technician_survey_report.py
@@ -3,7 +3,7 @@ from tap_logmeinrescue.streams.base import BaseLogMeInRescueReportStream
 
 class TechnicianSurveyReportStream(BaseLogMeInRescueReportStream):
     TABLE = 'technician_survey_report'
-    KEY_PROPERTIES = ['session_id']
+    KEY_PROPERTIES = []
     API_METHOD = 'GET'
     REPORT_AREA = 8
     REQUIRES = ['technicians']

--- a/tap_logmeinrescue/streams/transferred_sessions_extended_report.py
+++ b/tap_logmeinrescue/streams/transferred_sessions_extended_report.py
@@ -5,7 +5,7 @@ class TransferredSessionsExtendedReportStream(
     BaseLogMeInRescueReportStream
 ):
     TABLE = 'transferred_sessions_extended_report'
-    KEY_PROPERTIES = ['session_id']
+    KEY_PROPERTIES = []
     API_METHOD = 'GET'
     REPORT_AREA = 16
     REQUIRES = ['technicians']


### PR DESCRIPTION
Removes `session_id` as key property for:
- session_report
- technician_survey_report
- transferred_sessions_extended_report